### PR TITLE
Update PlacesApi.php

### DIFF
--- a/src/PlacesApi.php
+++ b/src/PlacesApi.php
@@ -57,11 +57,14 @@ class PlacesApi
      * @return \Illuminate\Support\Collection
      * @throws \SKAgarwal\GoogleApi\Exceptions\GooglePlacesApiException
      */
-    public function nearbySearch($location, $radius = null, $params = [])
+    public function nearbySearch($location=null, $radius = null, $params = [])
     {
         $this->checkKey();
 
-        $params = $this->prepareNearbySearchParams($location, $radius, $params);
+        if (!array_key_exists('pagetoken', $params)){
+            $params = $this->prepareNearbySearchParams($location, $radius, $params);
+        }
+        
         $response = $this->makeRequest(self::NEARBY_SEARCH_URL, $params);
 
         return $this->convertToCollection($response, 'results');


### PR DESCRIPTION
This modification is needed to use next_page_token, google places api will return an error if any other param is sent when next_page_token is present.


 $places = $this->googlePlaces->nearbySearch(
				array(
					'pagetoken' => 'token should be sent here'
				)
		  );