### PR TITLE
Fix typo & only display erro_message when it's in the response

### DIFF
--- a/src/PlacesApi.php
+++ b/src/PlacesApi.php
@@ -247,7 +247,7 @@ class PlacesApi
             AND $response['status'] !== 'ZERO_RESULTS') {
             throw new GooglePlacesApiException(
                 "Response returned with status: " . $response['status'] . "\n" .
-                "Error Messae: {$response['error_message']}"
+                array_key_exists('error_message', $response) ?: "Error Message: {$response['error_message']}"
             );
         }
         


### PR DESCRIPTION
FIxes an issue where the response doesn't contain a 'error_message'. Solution would be to just return the Exception without it.