### PR TITLE
Handle uncaught exception

### DIFF
--- a/src/PlacesApi.php
+++ b/src/PlacesApi.php
@@ -276,7 +276,8 @@ class PlacesApi
         $this->setStatus($response['status']);
         
         if ($response['status'] !== 'OK'
-            AND $response['status'] !== 'ZERO_RESULTS') {
+            AND $response['status'] !== 'ZERO_RESULTS'
+            AND $response['status'] !== 'OVER_QUERY_LIMIT') {
             throw new GooglePlacesApiException(
                 "Response returned with status: " . $response['status'] . "\n" .
                 array_key_exists('error_message', $response)


### PR DESCRIPTION
Fix for PHP Fatal error:  Uncaught exception 'SKAgarwal\\GoogleApi\\Exceptions\\GooglePlacesApiException' with message 'Response returned with status: OVER_QUERY_LIMIT